### PR TITLE
fix navigation and apply minimalistic theme

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -29,6 +29,7 @@ h3{margin:0}
 h4{margin:.2rem 0}
 p{color:var(--muted); margin:.4rem 0}
 a{color:inherit; text-decoration:none}
+a:hover{text-decoration:underline}
 
 /* ====== Layout ====== */
 .container{width:min(1120px,92%); margin-inline:auto}
@@ -48,7 +49,7 @@ a{color:inherit; text-decoration:none}
 }
 .nav{display:flex; align-items:center; justify-content:space-between; gap:1rem; padding:12px 0}
 .brand{display:flex; align-items:center; gap:.6rem; color:var(--ink); font-weight:800}
-.logo{width:36px; height:36px; border-radius:12px; background:linear-gradient(135deg,var(--leaf),var(--river))}
+.logo{width:36px; height:36px; border-radius:8px; border:2px solid var(--ink); background:none}
 .hamb{display:none; background:#fff; border:1px solid rgba(2,8,20,.06); border-radius:10px; padding:.4rem .6rem; cursor:pointer}
 
 .nav-list{display:flex; align-items:center; gap:.4rem; list-style:none; margin:0; padding:0}
@@ -58,8 +59,8 @@ a{color:inherit; text-decoration:none}
 }
 .nav-list a:hover{background:rgba(2,8,20,.05)}
 .nav-cta{
-  background: linear-gradient(135deg,var(--leaf),var(--river));
-  color:#fff !important; box-shadow: var(--shadow);
+  background: var(--ink);
+  color:#fff !important; box-shadow:none;
 }
 
 /* Mobile menu */
@@ -80,9 +81,9 @@ a{color:inherit; text-decoration:none}
 }
 
 /* ====== Buttons / Chips ====== */
-.btn{display:inline-flex; align-items:center; gap:.5rem; border:0; border-radius:12px; padding:.9rem 1.1rem; font-weight:700; cursor:pointer; box-shadow:var(--shadow)}
-.primary{background:linear-gradient(135deg,var(--leaf),var(--river)); color:#fff}
-.ghost{background:#fff; color:var(--leaf); border:2px solid rgba(16,111,77,.15)}
+.btn{display:inline-flex; align-items:center; gap:.5rem; border:1px solid transparent; border-radius:8px; padding:.8rem 1rem; font-weight:700; cursor:pointer; box-shadow:none}
+.primary{background:var(--ink); color:#fff}
+.ghost{background:#fff; color:var(--ink); border:1px solid var(--ink)}
 .actions{display:flex; gap:.6rem; flex-wrap:wrap}
 .chip{padding:.5rem .9rem; border-radius:999px; border:1px solid rgba(2,8,20,.12); background:#fff; font-weight:600; cursor:pointer}
 
@@ -103,7 +104,7 @@ a{color:inherit; text-decoration:none}
 }
 
 /* ====== Cards / Features ====== */
-.card{background:var(--card); border:1px solid rgba(2,8,20,.06); border-radius:var(--radius); padding:18px; box-shadow:var(--shadow)}
+.card{background:var(--card); border:1px solid rgba(2,8,20,.1); border-radius:var(--radius); padding:18px}
 .ico{width:42px; height:42px; border-radius:12px; margin-bottom:10px; box-shadow:inset 0 -10px 18px rgba(0,0,0,.06)}
 .i-gold{background:linear-gradient(135deg,var(--gold),#fff)}
 .i-blue{background:linear-gradient(135deg,var(--river),#fff)}
@@ -111,7 +112,7 @@ a{color:inherit; text-decoration:none}
 .i-orange{background:linear-gradient(135deg,var(--sunset),#fff)}
 .link{display:inline-block; margin-top:10px; font-weight:700; color:var(--leaf)}
 
-.feature{display:flex; gap:12px; align-items:flex-start; background:#fff; border:1px solid rgba(2,8,20,.06); border-radius:16px; padding:14px; box-shadow:var(--shadow)}
+.feature{display:flex; gap:12px; align-items:flex-start; background:#fff; border:1px solid rgba(2,8,20,.1); border-radius:16px; padding:14px}
 .dot{flex:0 0 18px; width:18px; height:18px; border-radius:50%; background:linear-gradient(135deg,var(--leaf),var(--river))}
 @media (max-width:1000px){ .grid-4{grid-template-columns:repeat(2,1fr)} .grid-3{grid-template-columns:repeat(2,1fr)} }
 @media (max-width:640px){ .grid-4,.grid-3{grid-template-columns:1fr} }
@@ -273,17 +274,17 @@ a{color:inherit; text-decoration:none}
   }
 }
 
-/* ==== MINI THEME – Glow-up rápido ==== */
+/* ==== Minimal Theme ==== */
 :root{
-  --bg:#f6f8f7;
+  --bg:#ffffff;
   --panel:#ffffff;
-  --ink:#0f172a;
-  --muted:#64748b;
-  --brand:#059669;          /* emerald-600 */
-  --brand-700:#047857;
-  --ring:#a7f3d0;           /* emerald-200 */
-  --radius:18px;
-  --shadow:0 10px 30px rgba(2,6,23,.08);
+  --ink:#111827;
+  --muted:#6b7280;
+  --brand:#111827;
+  --brand-700:#000000;
+  --ring:#e5e7eb;
+  --radius:8px;
+  --shadow:0 1px 2px rgba(0,0,0,.05);
 }
 
 html,body{background:var(--bg);color:var(--ink);}
@@ -301,9 +302,9 @@ h3{font-weight:700}
 /* cartões painéis */
 .card{
   background:var(--panel);
-  border:1px solid rgba(2,6,23,.06);
+  border:1px solid rgba(17,24,39,.1);
   border-radius:var(--radius);
-  box-shadow:var(--shadow);
+  box-shadow:none;
 }
 
 /* botões primários e chips (unifica estilos) */
@@ -311,13 +312,13 @@ h3{font-weight:700}
   border-radius:9999px !important;
   padding:.7rem 1.1rem !important;
   font-weight:700;
-  box-shadow:0 1px 2px rgba(2,6,23,.06);
-  border:1px solid rgba(2,6,23,.08);
+  box-shadow:none;
+  border:1px solid rgba(17,24,39,.1);
 }
 .btn--primary, .pf-primary, .nav-cta{
-  background:var(--brand) !important; color:#fff !important; border-color:transparent !important;
+  background:var(--ink) !important; color:#fff !important; border-color:var(--ink) !important;
 }
-.btn--primary:hover, .pf-primary:hover, .nav-cta:hover{ filter:brightness(.96); }
+.btn--primary:hover, .pf-primary:hover, .nav-cta:hover{ filter:brightness(.92); }
 
 /* inputs */
 input,select,textarea{
@@ -335,12 +336,12 @@ input:focus,select:focus,textarea:focus{
 .badge{
   display:inline-block; font-weight:700; font-size:.72rem;
   padding:.35rem .7rem; border-radius:9999px;
-  background:rgba(5,150,105,.12); color:var(--brand-700);
+  background:rgba(17,24,39,.06); color:var(--ink);
 }
 
 /* header/footer contraste sutil */
-.site-header{ backdrop-filter:saturate(120%) blur(6px); background:rgba(255,255,255,.72); border-bottom:1px solid rgba(2,6,23,.06)}
-.site-footer{ background:#0b1324; color:#cbd5e1; }
-.site-footer a{ color:#e2e8f0 }
+.site-header{ backdrop-filter:saturate(120%) blur(6px); background:rgba(255,255,255,.9); border-bottom:1px solid rgba(17,24,39,.06)}
+.site-footer{ background:#111827; color:#d1d5db; }
+.site-footer a{ color:#f3f4f6 }
 .site-footer .f-title{ color:#fff }
 

--- a/index.html
+++ b/index.html
@@ -23,14 +23,14 @@
   <header class="site-header">
     <div class="container nav tw-flex tw-items-center tw-justify-between">
       <!-- logo -->
-      <a class="brand" href="/">
+      <a class="brand" href="index.html">
         <span class="logo"></span>
         <strong>Chicas Eventos</strong>
       </a>
 
       <!-- hambúrguer (mobile apenas) -->
       <button
-        class="hamb tw-ml-auto tw-inline-flex tw-items-center tw-justify-center tw-p-2 tw-rounded-xl tw-border tw-border-gray-200 tw-bg-white tw-shadow-sm
+        class="hamb tw-ml-auto tw-inline-flex tw-items-center tw-justify-center tw-p-2 tw-rounded-xl tw-border tw-border-gray-200 tw-bg-white
                tw-block md:tw-hidden"
         id="hamb"
         aria-label="Abrir menu">☰</button>
@@ -38,7 +38,7 @@
       <!-- navegação (desktop apenas) -->
       <nav class="tw-hidden md:tw-block">
         <ul id="menu" class="nav-list">
-          <li><a href="pages/serviços.html">Serviços</a></li>
+          <li><a href="pages/servicos.html">Serviços</a></li>
           <li><a href="pages/portfolio.html">Portfólio</a></li>
           <li><a href="pages/sobre.html">Sobre</a></li>
           <li><a class="nav-cta" href="pages/briefing.html">Fazer orçamento</a></li>
@@ -48,7 +48,7 @@
 
     <!-- navegação (mobile) -->
     <ul id="menuMobile" class="nav-mobile">
-      <li><a href="pages/serviços.html">Serviços</a></li>
+      <li><a href="pages/servicos.html">Serviços</a></li>
       <li><a href="pages/portfolio.html">Portfólio</a></li>
       <li><a href="pages/sobre.html">Sobre</a></li>
       <li><a class="nav-cta" href="pages/briefing.html">Fazer orçamento</a></li>
@@ -57,7 +57,7 @@
 
   <main>
     <!-- SECTION 1 — HERO SPLIT -->
-    <section class="tw-w-full tw-bg-[#f7faf9] tw-py-10">
+    <section class="tw-w-full tw-bg-white tw-py-10">
       <div
         class="container tw-mx-auto tw-max-w-6xl
                tw-grid tw-grid-cols-1 md:tw-grid-cols-2
@@ -65,8 +65,8 @@
 
         <!-- Bloco branco (texto) -->
         <div
-          class="tw-bg-white tw-shadow-[0_10px_20px_rgba(0,0,0,.08),0_2px_6px_rgba(0,0,0,.04)]
-                 tw-rounded-t-[28px] md:tw-rounded-l-[28px] md:tw-rounded-tr-none
+          class="tw-bg-white tw-border tw-border-gray-200
+                 tw-rounded-t-lg md:tw-rounded-l-lg md:tw-rounded-tr-none
                  tw-p-8 md:tw-p-12
                  tw-flex tw-items-center
                  tw-h-auto md:tw-h-[440px]">
@@ -79,12 +79,12 @@
               para sua empresa com estética e eficiência.
             </p>
             <div class="tw-mt-6 tw-flex tw-gap-3">
-              <a href="/pages/briefing.html"
-                 class="tw-px-5 tw-py-3 tw-rounded-xl tw-bg-emerald-700 tw-text-white tw-font-semibold tw-shadow hover:tw-opacity-95 tw-transition">
+              <a href="pages/briefing.html"
+                 class="tw-px-5 tw-py-3 tw-rounded-lg tw-bg-slate-900 tw-text-white tw-font-semibold hover:tw-opacity-90 tw-transition">
                 Pedir orçamento
               </a>
-              <a href="/pages/portfolio.html"
-                 class="tw-px-5 tw-py-3 tw-rounded-xl tw-bg-white tw-text-slate-900 tw-font-semibold tw-shadow tw-border tw-border-slate-100 hover:tw-bg-slate-50 tw-transition">
+              <a href="pages/portfolio.html"
+                 class="tw-px-5 tw-py-3 tw-rounded-lg tw-bg-white tw-text-slate-900 tw-font-semibold tw-border tw-border-slate-300 hover:tw-bg-slate-50 tw-transition">
                 Ver portfólio
               </a>
             </div>
@@ -93,8 +93,8 @@
 
         <!-- Imagem -->
         <figure
-          class="tw-rounded-b-[28px] md:tw-rounded-r-[28px] md:tw-rounded-bl-none
-                 tw-overflow-hidden tw-shadow-[0_10px_20px_rgba(0,0,0,.08),0_2px_6px_rgba(0,0,0,.04)]
+          class="tw-rounded-b-lg md:tw-rounded-r-lg md:tw-rounded-bl-none
+                 tw-overflow-hidden tw-border tw-border-gray-200
                  tw-h-[260px] md:tw-h-[440px] tw-m-0">
           <img
             src="assets/public/img/1.jpg"
@@ -117,7 +117,7 @@
         <div class="tw-grid tw-gap-6 md:tw-grid-cols-4">
           <!-- Card base: reaproveitado 4x -->
           <!-- 1 Buffet -->
-          <article class="tw-relative tw-rounded-2xl tw-overflow-hidden tw-shadow hover:tw-shadow-lg tw-transition tw-h-[260px] md:tw-h-[300px]">
+          <article class="tw-relative tw-rounded-2xl tw-overflow-hidden tw-transition tw-h-[260px] md:tw-h-[300px]">
             <!-- imagem -->
             <img src="assets/public/img/ale.jpg" alt="Buffet corporativo"
                  class="tw-absolute tw-inset-0 tw-w-full tw-h-full tw-object-cover" />
@@ -127,47 +127,47 @@
             <div class="tw-relative tw-z-10 tw-h-full tw-flex tw-flex-col tw-justify-end tw-items-center tw-text-center tw-text-white tw-p-6">
               <h3 class="tw-font-bold tw-text-lg md:tw-text-xl">Buffet corporativo</h3>
               <p class="tw-text-white/85 tw-text-sm tw-mt-1">Coffee breaks, coquetéis e menus sob medida.</p>
-              <a class="tw-mt-3 tw-inline-block tw-font-semibold tw-text-emerald-300 hover:tw-text-emerald-200"
-                 href="/pages/servicos/buffet.html">Ver detalhes →</a>
+              <a class="tw-mt-3 tw-inline-block tw-font-semibold tw-text-slate-300 hover:tw-text-slate-500"
+                 href="pages/servicos/buffet.html">Ver detalhes →</a>
             </div>
           </article>
 
           <!-- 2 Audiovisual -->
-          <article class="tw-relative tw-rounded-2xl tw-overflow-hidden tw-shadow hover:tw-shadow-lg tw-transition tw-h-[260px] md:tw-h-[300px]">
+          <article class="tw-relative tw-rounded-2xl tw-overflow-hidden tw-transition tw-h-[260px] md:tw-h-[300px]">
             <img src="assets/public/img/ale.jpg" alt="Captação audiovisual"
                  class="tw-absolute tw-inset-0 tw-w-full tw-h-full tw-object-cover tw-object-center" />
             <div class="tw-absolute tw-inset-0 tw-bg-gradient-to-t tw-from-black/60 tw-via-black/30 tw-to-transparent"></div>
             <div class="tw-relative tw-z-10 tw-h-full tw-flex tw-flex-col tw-justify-end tw-items-center tw-text-center tw-text-white tw-p-6">
               <h3 class="tw-font-bold tw-text-lg md:tw-text-xl">Captação audiovisual</h3>
               <p class="tw-text-white/85 tw-text-sm tw-mt-1">Foto, vídeo, cobertura social e drone.</p>
-              <a class="tw-mt-3 tw-inline-block tw-font-semibold tw-text-emerald-300 hover:tw-text-emerald-200"
-                 href="/pages/servicos/audiovisual.html">Ver detalhes →</a>
+              <a class="tw-mt-3 tw-inline-block tw-font-semibold tw-text-slate-300 hover:tw-text-slate-500"
+                 href="pages/servicos/audiovisual.html">Ver detalhes →</a>
             </div>
           </article>
 
           <!-- 3 RH -->
-          <article class="tw-relative tw-rounded-2xl tw-overflow-hidden tw-shadow hover:tw-shadow-lg tw-transition tw-h-[260px] md:tw-h-[300px]">
+          <article class="tw-relative tw-rounded-2xl tw-overflow-hidden tw-transition tw-h-[260px] md:tw-h-[300px]">
             <img src="assets/public/img/ale.jpg" alt="Recursos humanos"
                  class="tw-absolute tw-inset-0 tw-w-full tw-h-full tw-object-cover tw-object-center" />
             <div class="tw-absolute tw-inset-0 tw-bg-gradient-to-t tw-from-black/60 tw-via-black/30 tw-to-transparent"></div>
             <div class="tw-relative tw-z-10 tw-h-full tw-flex tw-flex-col tw-justify-end tw-items-center tw-text-center tw-text-white tw-p-6">
               <h3 class="tw-font-bold tw-text-lg md:tw-text-xl">Recursos humanos</h3>
               <p class="tw-text-white/85 tw-text-sm tw-mt-1">Recepção, apoio e controle de acesso.</p>
-              <a class="tw-mt-3 tw-inline-block tw-font-semibold tw-text-emerald-300 hover:tw-text-emerald-200"
-                 href="/pages/servicos/rh.html">Ver detalhes →</a>
+              <a class="tw-mt-3 tw-inline-block tw-font-semibold tw-text-slate-300 hover:tw-text-slate-500"
+                 href="pages/servicos/rh.html">Ver detalhes →</a>
             </div>
           </article>
 
           <!-- 4 Cerimonial -->
-          <article class="tw-relative tw-rounded-2xl tw-overflow-hidden tw-shadow hover:tw-shadow-lg tw-transition tw-h-[260px] md:tw-h-[300px]">
+          <article class="tw-relative tw-rounded-2xl tw-overflow-hidden tw-transition tw-h-[260px] md:tw-h-[300px]">
             <img src="assets/public/img/ale.jpg" alt="Organização & cerimonial"
                  class="tw-absolute tw-inset-0 tw-w-full tw-h-full tw-object-cover tw-object-center" />
             <div class="tw-absolute tw-inset-0 tw-bg-gradient-to-t tw-from-black/60 tw-via-black/30 tw-to-transparent"></div>
             <div class="tw-relative tw-z-10 tw-h-full tw-flex tw-flex-col tw-justify-end tw-items-center tw-text-center tw-text-white tw-p-6">
               <h3 class="tw-font-bold tw-text-lg md:tw-text-xl">Organização & cerimonial</h3>
               <p class="tw-text-white/85 tw-text-sm tw-mt-1">Planejamento, fornecedores e execução.</p>
-              <a class="tw-mt-3 tw-inline-block tw-font-semibold tw-text-emerald-300 hover:tw-text-emerald-200"
-                 href="/pages/servicos/cerimonial.html">Ver detalhes →</a>
+              <a class="tw-mt-3 tw-inline-block tw-font-semibold tw-text-slate-300 hover:tw-text-slate-500"
+                 href="pages/servicos/cerimonial.html">Ver detalhes →</a>
             </div>
           </article>
         </div>
@@ -192,9 +192,9 @@
     <div class="tw-grid tw-gap-6 md:tw-grid-cols-3">
       
       <!-- Integração completa -->
-      <article class="tw-bg-white tw-rounded-xl tw-shadow tw-p-6 tw-text-left hover:tw-shadow-lg tw-transition">
+      <article class="tw-bg-white tw-rounded-xl tw-p-6 tw-text-left tw-transition">
         <div class="tw-flex tw-items-center tw-gap-3 tw-mb-2">
-          <svg class="tw-w-6 tw-h-6 tw-text-emerald-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <svg class="tw-w-6 tw-h-6 tw-text-slate-900" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path d="M12 6v6h6" stroke-linecap="round" stroke-linejoin="round"/>
             <circle cx="12" cy="12" r="10" />
           </svg>
@@ -204,9 +204,9 @@
       </article>
       
       <!-- Agilidade garantida -->
-      <article class="tw-bg-white tw-rounded-xl tw-shadow tw-p-6 tw-text-left hover:tw-shadow-lg tw-transition">
+      <article class="tw-bg-white tw-rounded-xl tw-p-6 tw-text-left tw-transition">
         <div class="tw-flex tw-items-center tw-gap-3 tw-mb-2">
-          <svg class="tw-w-6 tw-h-6 tw-text-emerald-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <svg class="tw-w-6 tw-h-6 tw-text-slate-900" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path d="M12 8v4l3 3" stroke-linecap="round" stroke-linejoin="round"/>
             <circle cx="12" cy="12" r="10" />
           </svg>
@@ -216,9 +216,9 @@
       </article>
       
       <!-- Beleza funcional -->
-      <article class="tw-bg-white tw-rounded-xl tw-shadow tw-p-6 tw-text-left hover:tw-shadow-lg tw-transition">
+      <article class="tw-bg-white tw-rounded-xl tw-p-6 tw-text-left tw-transition">
         <div class="tw-flex tw-items-center tw-gap-3 tw-mb-2">
-          <svg class="tw-w-6 tw-h-6 tw-text-emerald-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <svg class="tw-w-6 tw-h-6 tw-text-slate-900" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path d="M4 6h16M4 12h16M4 18h7" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
           <h4 class="tw-font-bold tw-text-lg">Beleza funcional</h4>
@@ -227,9 +227,9 @@
       </article>
       
       <!-- Identidade regional -->
-      <article class="tw-bg-white tw-rounded-xl tw-shadow tw-p-6 tw-text-left hover:tw-shadow-lg tw-transition">
+      <article class="tw-bg-white tw-rounded-xl tw-p-6 tw-text-left tw-transition">
         <div class="tw-flex tw-items-center tw-gap-3 tw-mb-2">
-          <svg class="tw-w-6 tw-h-6 tw-text-emerald-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <svg class="tw-w-6 tw-h-6 tw-text-slate-900" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path d="M12 2l4 8h-8l4-8zM2 22h20l-10-8-10 8z" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
           <h4 class="tw-font-bold tw-text-lg">Identidade regional</h4>
@@ -238,9 +238,9 @@
       </article>
       
       <!-- Rede confiável -->
-      <article class="tw-bg-white tw-rounded-xl tw-shadow tw-p-6 tw-text-left hover:tw-shadow-lg tw-transition">
+      <article class="tw-bg-white tw-rounded-xl tw-p-6 tw-text-left tw-transition">
         <div class="tw-flex tw-items-center tw-gap-3 tw-mb-2">
-          <svg class="tw-w-6 tw-h-6 tw-text-emerald-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <svg class="tw-w-6 tw-h-6 tw-text-slate-900" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path d="M5 13l4 4L19 7" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
           <h4 class="tw-font-bold tw-text-lg">Rede confiável</h4>
@@ -249,9 +249,9 @@
       </article>
       
       <!-- Acompanhamento total -->
-      <article class="tw-bg-white tw-rounded-xl tw-shadow tw-p-6 tw-text-left hover:tw-shadow-lg tw-transition">
+      <article class="tw-bg-white tw-rounded-xl tw-p-6 tw-text-left tw-transition">
         <div class="tw-flex tw-items-center tw-gap-3 tw-mb-2">
-          <svg class="tw-w-6 tw-h-6 tw-text-emerald-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <svg class="tw-w-6 tw-h-6 tw-text-slate-900" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
             <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7H3v12a2 2 0 002 2z" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
           <h4 class="tw-font-bold tw-text-lg">Acompanhamento total</h4>
@@ -263,7 +263,7 @@
   </div>
 </section>
 <!-- =============== SECTION — PORTFÓLIO (ESTEIRA + FILTROS, BOTÕES EM UMA LINHA) =============== -->
-<section class="tw-bg-[#f7faf9] tw-py-16">
+<section class="tw-bg-white tw-py-16">
   <div class="container tw-mx-auto tw-max-w-6xl">
 
     <!-- Cabeçalho -->
@@ -279,7 +279,7 @@
 
       <!-- Botões: todos iguais e em uma só linha -->
       <div class="tw-flex tw-flex-wrap tw-gap-3">
-        <a href="/pages/portfolio.html"
+        <a href="pages/portfolio.html"
            class="pf-chip pf-primary">Ver portfólio</a>
 
         <button class="pf-chip pf-active" data-filter="all">Todas</button>
@@ -292,10 +292,10 @@
 
     <!-- Esteiras -->
     <div class="tw-space-y-4">
-      <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl tw-shadow">
+      <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl">
         <div id="pf-track-1" class="pf-track pf-track-rtl"></div>
       </div>
-      <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl tw-shadow">
+      <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl">
         <div id="pf-track-2" class="pf-track pf-track-rtl pf-slower"></div>
       </div>
     </div>
@@ -424,8 +424,8 @@
       class="tw-flex tw-flex-col tw-items-center tw-text-center
              tw-rounded-2xl md:tw-rounded-[28px]
              tw-px-6 md:tw-px-10 tw-py-10
-             tw-bg-gradient-to-r tw-from-emerald-50 tw-to-sky-50
-             tw-border tw-border-emerald-100 tw-shadow-sm">
+             tw-bg-white
+             tw-border tw-border-gray-200">
 
       <!-- Texto -->
       <h3 class="tw-text-2xl md:tw-text-3xl tw-font-extrabold tw-text-slate-900">
@@ -438,9 +438,9 @@
       <!-- Botão -->
       <a href="pages/briefing.html"
          class="tw-mt-6 tw-inline-flex tw-items-center tw-justify-center
-                tw-px-6 tw-py-3 tw-rounded-xl
-                tw-bg-emerald-700 tw-text-white tw-font-semibold
-                tw-shadow hover:tw-opacity-95 tw-transition">
+                tw-px-6 tw-py-3 tw-rounded-lg
+                tw-bg-slate-900 tw-text-white tw-font-semibold
+                hover:tw-opacity-90 tw-transition">
         Seu orçamento agora
       </a>
     </div>
@@ -478,10 +478,10 @@
       <div class="f-col">
         <h4 class="f-title">Navegue pelo site</h4>
         <ul class="f-links">
-          <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-          <li><a href="/pages/portfolio.html">Galeria</a></li>
-          <li><a href="/pages/sobre.html">Sobre Nós</a></li>
-          <li><a href="/pages/briefing.html">Contato</a></li>
+          <li><a href="pages/servicos/buffet.html">Buffet</a></li>
+          <li><a href="pages/portfolio.html">Galeria</a></li>
+          <li><a href="pages/sobre.html">Sobre Nós</a></li>
+          <li><a href="pages/briefing.html">Contato</a></li>
         </ul>
       </div>
 

--- a/pages/briefing.html
+++ b/pages/briefing.html
@@ -11,39 +11,39 @@
     tailwind.config = { prefix: 'tw-', corePlugins: { preflight: false } };
   </script>
 </head>
-<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-[#f7faf9]">
+<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-white">
 
   <!-- HEADER -->
   <header class="site-header">
     <div class="container nav">
-      <a class="brand" href="/"><span class="logo"></span><strong>Chicas Eventos</strong></a>
+      <a class="brand" href="../index.html"><span class="logo"></span><strong>Chicas Eventos</strong></a>
       <button class="hamb md:tw-hidden" id="hamb" aria-label="Abrir menu">☰</button>
       <nav class="tw-hidden md:tw-block">
         <ul class="nav-list">
-          <li><a href="/pages/servicos.html">Serviços</a></li>
-          <li><a href="/pages/portfolio.html">Portfólio</a></li>
-          <li><a href="/pages/sobre.html">Sobre</a></li>
-          <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+          <li><a href="servicos.html">Serviços</a></li>
+          <li><a href="portfolio.html">Portfólio</a></li>
+          <li><a href="sobre.html">Sobre</a></li>
+          <li><a class="nav-cta" href="briefing.html">Fazer orçamento</a></li>
         </ul>
       </nav>
     </div>
     <ul id="menuMobile" class="nav-mobile" style="display:none">
-      <li><a href="/pages/servicos.html">Serviços</a></li>
-      <li><a href="/pages/portfolio.html">Portfólio</a></li>
-      <li><a href="/pages/sobre.html">Sobre</a></li>
-      <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+      <li><a href="servicos.html">Serviços</a></li>
+      <li><a href="portfolio.html">Portfólio</a></li>
+      <li><a href="sobre.html">Sobre</a></li>
+      <li><a class="nav-cta" href="briefing.html">Fazer orçamento</a></li>
     </ul>
   </header>
 
   <!-- CONTEÚDO -->
   <main class="tw-flex-1 tw-py-10">
     <div class="tw-container tw-mx-auto tw-max-w-6xl tw-px-4">
-      <section class="tw-mx-auto tw-max-w-3xl tw-p-0 tw-rounded-[28px] tw-border tw-border-slate-200 tw-shadow-2xl tw-bg-white/85 tw-backdrop-blur-sm tw-overflow-hidden">
+      <section class="tw-mx-auto tw-max-w-3xl tw-p-0 tw-rounded-[28px] tw-border tw-border-slate-200 tw-bg-white/85 tw-backdrop-blur-sm tw-overflow-hidden">
         
         <!-- Cabeçalho do balão -->
         <div class="tw-px-6 tw-pt-6 md:tw-px-10 md:tw-pt-10">
           <div class="tw-text-center">
-            <span class="tw-text-xs tw-tracking-wide tw-font-semibold tw-text-emerald-700 tw-uppercase">Orçamento</span>
+            <span class="tw-text-xs tw-tracking-wide tw-font-semibold tw-text-slate-900 tw-uppercase">Orçamento</span>
             <h1 class="tw-text-3xl md:tw-text-4xl tw-font-extrabold tw-text-slate-900 tw-mt-1">Briefing rápido</h1>
             <p class="tw-text-slate-600 tw-mt-2">Leva menos de 2 min. Assim entendemos sua necessidade e preparamos um orçamento sob medida.</p>
           </div>
@@ -53,7 +53,7 @@
         <div class="tw-px-6 md:tw-px-10 tw-mt-4">
           <div class="tw-flex tw-justify-center">
             <div class="tw-w-[88%] md:tw-w-[82%] tw-max-w-[680px] tw-h-[6px] tw-bg-slate-100 tw-rounded-full">
-              <div id="progressBar" class="tw-h-full tw-bg-emerald-600 tw-rounded-full tw-w-[12%] tw-transition-all tw-duration-300"></div>
+              <div id="progressBar" class="tw-h-full tw-bg-slate-900 tw-rounded-full tw-w-[12%] tw-transition-all tw-duration-300"></div>
             </div>
           </div>
         </div>
@@ -67,15 +67,15 @@
               <div class="tw-grid tw-gap-4 md:tw-grid-cols-2">
                 <div class="md:tw-col-span-2">
                   <label class="tw-text-sm tw-font-semibold tw-text-slate-700">Nome</label>
-                  <input class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-shadow-sm tw-text-slate-900 placeholder:tw-text-slate-400 focus:tw-outline-none focus:tw-border-emerald-400" name="nome" required placeholder="Seu nome completo">
+                  <input class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-text-slate-900 placeholder:tw-text-slate-400 focus:tw-outline-none focus:tw-border-slate-700" name="nome" required placeholder="Seu nome completo">
                 </div>
                 <div>
                   <label class="tw-text-sm tw-font-semibold tw-text-slate-700">Telefone</label>
-                  <input class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-shadow-sm tw-text-slate-900 placeholder:tw-text-slate-400 focus:tw-outline-none focus:tw-border-emerald-400" name="telefone" required placeholder="(00) 00000-0000">
+                  <input class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-text-slate-900 placeholder:tw-text-slate-400 focus:tw-outline-none focus:tw-border-slate-700" name="telefone" required placeholder="(00) 00000-0000">
                 </div>
                 <div>
                   <label class="tw-text-sm tw-font-semibold tw-text-slate-700">E-mail</label>
-                  <input type="email" class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-shadow-sm tw-text-slate-900 placeholder:tw-text-slate-400 focus:tw-outline-none focus:tw-border-emerald-400" name="email" required placeholder="voce@email.com">
+                  <input type="email" class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-text-slate-900 placeholder:tw-text-slate-400 focus:tw-outline-none focus:tw-border-slate-700" name="email" required placeholder="voce@email.com">
                 </div>
               </div>
             </div>
@@ -83,7 +83,7 @@
             <!-- STEP 2 -->
             <div class="step" data-step="2" style="display:none">
               <h2 class="tw-text-base tw-font-bold tw-text-slate-900 tw-mb-3">2) Que tipo de evento será?</h2>
-              <select class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-shadow-sm tw-text-slate-900 focus:tw-outline-none focus:tw-border-emerald-400" name="tipo_evento" required>
+              <select class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-text-slate-900 focus:tw-outline-none focus:tw-border-slate-700" name="tipo_evento" required>
                 <option value="" disabled selected>Selecione…</option>
                 <option>Corporativo</option>
                 <option>Conferência / Feira</option>
@@ -98,19 +98,19 @@
             <div class="step" data-step="3" style="display:none">
               <h2 class="tw-text-base tw-font-bold tw-text-slate-900 tw-mb-3">3) Buffet</h2>
               <div class="tw-flex tw-gap-3 tw-flex-wrap tw-mb-3">
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-toggle="buffet" data-value="sim">Preciso de buffet</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-toggle="buffet" data-value="nao">Não preciso</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300 tw-transition" data-toggle="buffet" data-value="sim">Preciso de buffet</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300 tw-transition" data-toggle="buffet" data-value="nao">Não preciso</button>
               </div>
               <div id="buffetTipos" class="tw-hidden tw-grid tw-gap-3 md:tw-grid-cols-2">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700 md:tw-col-span-2">Que tipo de buffet?</label>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Coffee break">Coffee break</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Coquetel">Coquetel</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Brunch">Brunch</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Almoço/Jantar">Almoço/Jantar</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Coffee break">Coffee break</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Coquetel">Coquetel</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Brunch">Brunch</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Almoço/Jantar">Almoço/Jantar</button>
               </div>
               <div id="buffetCustomWrap" class="tw-hidden tw-mt-4">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700">Preferências do buffet (opcional)</label>
-                <textarea class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-shadow-sm tw-text-slate-900 focus:tw-outline-none focus:tw-border-emerald-400" rows="3" name="buffet_custom" placeholder="Ex.: Coquetel com opções sem lactose, incluir sucos naturais..."></textarea>
+                <textarea class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-text-slate-900 focus:tw-outline-none focus:tw-border-slate-700" rows="3" name="buffet_custom" placeholder="Ex.: Coquetel com opções sem lactose, incluir sucos naturais..."></textarea>
               </div>
             </div>
 
@@ -118,16 +118,16 @@
             <div class="step" data-step="4" style="display:none">
               <h2 class="tw-text-base tw-font-bold tw-text-slate-900 tw-mb-3">4) Cobertura audiovisual</h2>
               <div class="tw-flex tw-gap-3 tw-flex-wrap tw-mb-3">
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-toggle="aud" data-value="sim">Preciso de cobertura</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-toggle="aud" data-value="nao">Não preciso</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300 tw-transition" data-toggle="aud" data-value="sim">Preciso de cobertura</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300 tw-transition" data-toggle="aud" data-value="nao">Não preciso</button>
               </div>
               <div id="audTipos" class="tw-hidden tw-grid tw-gap-3 md:tw-grid-cols-3">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700 md:tw-col-span-3">De que tipo?</label>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Foto">Foto</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Vídeo">Vídeo</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Drone">Drone</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Social media (reels/stories)">Social media</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Pacote completo">Pacote completo</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Foto">Foto</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Vídeo">Vídeo</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Drone">Drone</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Social media (reels/stories)">Social media</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Pacote completo">Pacote completo</button>
               </div>
             </div>
 
@@ -135,15 +135,15 @@
             <div class="step" data-step="5" style="display:none">
               <h2 class="tw-text-base tw-font-bold tw-text-slate-900 tw-mb-3">5) Equipe operacional (RH)</h2>
               <div class="tw-flex tw-gap-3 tw-flex-wrap tw-mb-3">
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-toggle="rh" data-value="sim">Preciso de equipe</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-toggle="rh" data-value="nao">Não preciso</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-toggle="rh" data-value="sim">Preciso de equipe</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-toggle="rh" data-value="nao">Não preciso</button>
               </div>
               <div id="rhTipos" class="tw-hidden tw-grid tw-gap-3 md:tw-grid-cols-2">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700 md:tw-col-span-2">Qual(is) desses?</label>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Garçom">Garçom</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Recepcionista">Recepcionista</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Segurança">Segurança</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Apoio/Operacional">Apoio/Operacional</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Garçom">Garçom</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Recepcionista">Recepcionista</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Segurança">Segurança</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Apoio/Operacional">Apoio/Operacional</button>
               </div>
             </div>
 
@@ -152,20 +152,20 @@
               <h2 class="tw-text-base tw-font-bold tw-text-slate-900 tw-mb-3">6) Cerimonial</h2>
               <p class="tw-text-slate-700 tw-mb-3">Nosso cerimonial cuida do planejamento completo, cronograma, fornecedores e execução no dia.</p>
               <div class="tw-flex tw-gap-3 tw-flex-wrap">
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-toggle="cerim" data-value="sim">Quero cerimonial</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-toggle="cerim" data-value="nao">Não preciso</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-toggle="cerim" data-value="sim">Quero cerimonial</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 hover:tw-border-slate-300" data-toggle="cerim" data-value="nao">Não preciso</button>
               </div>
               <div class="tw-mt-4">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700">Observações (opcional)</label>
-                <textarea class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-shadow-sm tw-text-slate-900 focus:tw-outline-none focus:tw-border-emerald-400" rows="3" name="obs" placeholder="Datas, horários, local, estimativa de público…"></textarea>
+                <textarea class="tw-w-full tw-px-4 tw-py-3 tw-rounded-xl tw-border tw-border-slate-200 tw-text-slate-900 focus:tw-outline-none focus:tw-border-slate-700" rows="3" name="obs" placeholder="Datas, horários, local, estimativa de público…"></textarea>
               </div>
             </div>
 
             <!-- Navegação -->
             <div class="tw-flex tw-justify-between tw-items-center">
-              <button type="button" id="prevBtn" class="tw-inline-flex tw-items-center tw-justify-center tw-px-5 tw-py-3 tw-rounded-xl tw-font-semibold tw-shadow tw-bg-white tw-text-slate-900 tw-border tw-border-slate-200 hover:tw-bg-slate-50">← Voltar</button>
+              <button type="button" id="prevBtn" class="tw-inline-flex tw-items-center tw-justify-center tw-px-5 tw-py-3 tw-rounded-xl tw-font-semibold tw-bg-white tw-text-slate-900 tw-border tw-border-slate-200 hover:tw-bg-slate-50">← Voltar</button>
               <div class="tw-flex tw-gap-2">
-                <button type="button" id="nextBtn" class="tw-inline-flex tw-items-center tw-justify-center tw-px-5 tw-py-3 tw-rounded-xl tw-font-semibold tw-shadow tw-bg-emerald-700 tw-text-white hover:tw-opacity-95">Próximo →</button>
+                <button type="button" id="nextBtn" class="tw-inline-flex tw-items-center tw-justify-center tw-px-5 tw-py-3 tw-rounded-xl tw-font-semibold tw-bg-slate-900 tw-text-white hover:tw-opacity-95">Próximo →</button>
               </div>
             </div>
           </form>
@@ -190,10 +190,10 @@
       <div class="f-col">
         <h4 class="f-title">Navegue pelo site</h4>
         <ul class="f-links">
-          <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-          <li><a href="/pages/portfolio.html">Galeria</a></li>
-          <li><a href="/pages/sobre.html">Sobre Nós</a></li>
-          <li><a href="/pages/briefing.html">Contato</a></li>
+          <li><a href="servicos/buffet.html">Buffet</a></li>
+          <li><a href="portfolio.html">Galeria</a></li>
+          <li><a href="sobre.html">Sobre Nós</a></li>
+          <li><a href="briefing.html">Contato</a></li>
         </ul>
       </div>
       <div class="f-col">
@@ -257,9 +257,9 @@
     function toggleSingle(group, value){
       document.querySelectorAll(`.tw-inline-flex[data-toggle="${group}"]`).forEach(el=>{
         el.dataset.checked = (el.dataset.value===value)?"true":"false";
-        el.classList.toggle('tw-bg-emerald-700', el.dataset.checked==="true");
+        el.classList.toggle('tw-bg-slate-900', el.dataset.checked==="true");
         el.classList.toggle('tw-text-white', el.dataset.checked==="true");
-        el.classList.toggle('tw-border-emerald-700', el.dataset.checked==="true");
+        el.classList.toggle('tw-border-slate-900', el.dataset.checked==="true");
       });
       state[group] = value;
       if(group==='buffet'){
@@ -269,7 +269,7 @@
           state.tipo_buffet.clear();
           document.querySelectorAll('[data-multi="tipo_buffet"]').forEach(b=>{
             b.dataset.checked="false";
-            b.classList.remove('tw-bg-emerald-700','tw-text-white','tw-border-emerald-700');
+            b.classList.remove('tw-bg-slate-900','tw-text-white','tw-border-slate-900');
           });
           const tx = document.querySelector('[name="buffet_custom"]'); if (tx) tx.value='';
         }
@@ -280,7 +280,7 @@
           state.tipo_aud.clear();
           document.querySelectorAll('[data-multi="tipo_aud"]').forEach(b=>{
             b.dataset.checked="false";
-            b.classList.remove('tw-bg-emerald-700','tw-text-white','tw-border-emerald-700');
+            b.classList.remove('tw-bg-slate-900','tw-text-white','tw-border-slate-900');
           });
         }
       }
@@ -290,7 +290,7 @@
           state.tipo_rh.clear();
           document.querySelectorAll('[data-multi="tipo_rh"]').forEach(b=>{
             b.dataset.checked="false";
-            b.classList.remove('tw-bg-emerald-700','tw-text-white','tw-border-emerald-700');
+            b.classList.remove('tw-bg-slate-900','tw-text-white','tw-border-slate-900');
           });
         }
       }
@@ -301,11 +301,11 @@
       if(set.has(value)){
         set.delete(value);
         el.dataset.checked="false";
-        el.classList.remove('tw-bg-emerald-700','tw-text-white','tw-border-emerald-700');
+        el.classList.remove('tw-bg-slate-900','tw-text-white','tw-border-slate-900');
       } else {
         set.add(value);
         el.dataset.checked="true";
-        el.classList.add('tw-bg-emerald-700','tw-text-white','tw-border-emerald-700');
+        el.classList.add('tw-bg-slate-900','tw-text-white','tw-border-slate-900');
       }
     }
     document.querySelectorAll('[data-toggle]').forEach(btn=> btn.addEventListener('click', ()=> toggleSingle(btn.dataset.toggle, btn.dataset.value)));
@@ -340,7 +340,7 @@
 
     function showStatus(ok,msg){
       statusBox.className='tw-mt-6 tw-text-center';
-      statusBox.classList.add(ok?'tw-text-emerald-700':'tw-text-red-600');
+      statusBox.classList.add(ok?'tw-text-slate-900':'tw-text-red-600');
       statusBox.innerHTML=`<div class="tw-font-semibold">${msg}</div>`;
       statusBox.classList.remove('tw-hidden');
     }
@@ -364,9 +364,9 @@
       steps.forEach(s => s.style.display='none');
       const msg = `
         <div class="tw-text-center tw-space-y-4 tw-pt-4">
-          <h3 class="tw-text-2xl tw-font-extrabold tw-text-emerald-700">Briefing enviado!</h3>
+          <h3 class="tw-text-2xl tw-font-extrabold tw-text-slate-900">Briefing enviado!</h3>
           <p class="tw-text-slate-700">Em instantes a nossa equipe irá entrar em contato. Muito obrigado.</p>
-          <a href="/pages/portfolio.html" class="tw-inline-flex tw-items-center tw-justify-center tw-px-6 tw-py-3 tw-rounded-xl tw-font-semibold tw-shadow tw-bg-emerald-700 tw-text-white hover:tw-opacity-95">
+          <a href="portfolio.html" class="tw-inline-flex tw-items-center tw-justify-center tw-px-6 tw-py-3 tw-rounded-xl tw-font-semibold tw-bg-slate-900 tw-text-white hover:tw-opacity-95">
             Ver portfólio →
           </a>
         </div>

--- a/pages/portfolio.html
+++ b/pages/portfolio.html
@@ -28,27 +28,27 @@
     .pf-modal.open{display:flex}
   </style>
 </head>
-<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-[#f7faf9]">
+<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-white">
 
   <!-- HEADER igual -->
   <header class="site-header">
     <div class="container nav">
-      <a class="brand" href="/"><span class="logo"></span><strong>Chicas Eventos</strong></a>
+      <a class="brand" href="../index.html"><span class="logo"></span><strong>Chicas Eventos</strong></a>
       <button class="hamb md:tw-hidden" id="hamb" aria-label="Abrir menu">☰</button>
       <nav class="tw-hidden md:tw-block">
         <ul class="nav-list">
-          <li><a href="/pages/servicos.html">Serviços</a></li>
-          <li><a class="is-active" href="/pages/portfolio.html">Portfólio</a></li>
-          <li><a href="/pages/sobre.html">Sobre</a></li>
-          <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+          <li><a href="servicos.html">Serviços</a></li>
+          <li><a class="is-active" href="portfolio.html">Portfólio</a></li>
+          <li><a href="sobre.html">Sobre</a></li>
+          <li><a class="nav-cta" href="briefing.html">Fazer orçamento</a></li>
         </ul>
       </nav>
     </div>
     <ul id="menuMobile" class="nav-mobile" style="display:none">
-      <li><a href="/pages/servicos.html">Serviços</a></li>
-      <li><a href="/pages/portfolio.html">Portfólio</a></li>
-      <li><a href="/pages/sobre.html">Sobre</a></li>
-      <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+      <li><a href="servicos.html">Serviços</a></li>
+      <li><a href="portfolio.html">Portfólio</a></li>
+      <li><a href="sobre.html">Sobre</a></li>
+      <li><a class="nav-cta" href="briefing.html">Fazer orçamento</a></li>
     </ul>
   </header>
 
@@ -66,7 +66,7 @@
 
         <!-- Filtros continuam (opcional) — "Todas" mostra TODAS as fotos -->
         <div class="tw-flex tw-flex-wrap tw-gap-3">
-          <a href="/pages/portfolio.html" class="pf-chip pf-primary">Ver portfólio</a>
+          <a href="portfolio.html" class="pf-chip pf-primary">Ver portfólio</a>
           <button class="pf-chip pf-active" data-filter="all">Todas</button>
           <button class="pf-chip" data-filter="buffet">Buffet</button>
           <button class="pf-chip" data-filter="aud">Audiovisual</button>
@@ -77,22 +77,22 @@
 
       <!-- 6 Esteiras -->
       <div class="tw-space-y-4">
-        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl tw-shadow">
+        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl">
           <div id="pf-track-1" class="pf-track pf-track-rtl"></div>
         </div>
-        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl tw-shadow">
+        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl">
           <div id="pf-track-2" class="pf-track pf-track-rtl pf-slower"></div>
         </div>
-        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl tw-shadow">
+        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl">
           <div id="pf-track-3" class="pf-track pf-track-rtl pf-slowest"></div>
         </div>
-        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl tw-shadow">
+        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl">
           <div id="pf-track-4" class="pf-track pf-track-rtl"></div>
         </div>
-        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl tw-shadow">
+        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl">
           <div id="pf-track-5" class="pf-track pf-track-rtl pf-slower"></div>
         </div>
-        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl tw-shadow">
+        <div class="pf-marquee-wrap tw-overflow-hidden tw-rounded-2xl">
           <div id="pf-track-6" class="pf-track pf-track-rtl pf-slowest"></div>
         </div>
       </div>
@@ -101,7 +101,7 @@
 
   <!-- MODAL -->
   <div id="pfModal" class="pf-modal tw-items-center tw-justify-center tw-px-4">
-    <div class="tw-bg-white tw-rounded-2xl tw-w-full tw-max-w-4xl tw-shadow-2xl tw-overflow-hidden">
+    <div class="tw-bg-white tw-rounded-2xl tw-w-full tw-max-w-4xl tw-overflow-hidden">
       <div class="tw-flex tw-justify-between tw-items-start tw-gap-4 tw-p-5 tw-border-b tw-border-slate-200">
         <div>
           <h3 id="mTitle" class="tw-text-xl md:tw-text-2xl tw-font-extrabold tw-text-slate-900">Evento</h3>
@@ -117,8 +117,8 @@
         <div class="md:tw-col-span-2">
           <div class="tw-relative tw-rounded-xl tw-overflow-hidden tw-aspect-[16/9] tw-bg-slate-100">
             <img id="mHero" src="" alt="" class="tw-absolute tw-inset-0 tw-w-full tw-h-full tw-object-cover">
-            <button id="mPrev" class="tw-absolute tw-left-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2 tw-shadow" aria-label="Anterior">‹</button>
-            <button id="mNext" class="tw-absolute tw-right-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2 tw-shadow" aria-label="Próxima">›</button>
+            <button id="mPrev" class="tw-absolute tw-left-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2" aria-label="Anterior">‹</button>
+            <button id="mNext" class="tw-absolute tw-right-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2" aria-label="Próxima">›</button>
           </div>
           <div id="mThumbs" class="tw-grid tw-grid-cols-5 tw-gap-2 tw-mt-3"></div>
         </div>
@@ -140,10 +140,10 @@
       <div class="f-col">
         <h4 class="f-title">Navegue pelo site</h4>
         <ul class="f-links">
-          <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-          <li><a href="/pages/portfolio.html">Galeria</a></li>
-          <li><a href="/pages/sobre.html">Sobre Nós</a></li>
-          <li><a href="/pages/briefing.html">Contato</a></li>
+          <li><a href="servicos/buffet.html">Buffet</a></li>
+          <li><a href="portfolio.html">Galeria</a></li>
+          <li><a href="sobre.html">Sobre Nós</a></li>
+          <li><a href="briefing.html">Contato</a></li>
         </ul>
       </div>
       <div class="f-col">
@@ -389,7 +389,7 @@
       mHero.alt = `Foto ${index+1}`;
       Array.from(mThumbs.children).forEach((t,i)=>{
         t.classList.toggle('tw-ring-2', i===index);
-        t.classList.toggle('tw-ring-emerald-600', i===index);
+        t.classList.toggle('tw-ring-slate-900', i===index);
       });
     }
 

--- a/pages/servicos.html
+++ b/pages/servicos.html
@@ -9,27 +9,27 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script> tailwind.config = { prefix: 'tw-', corePlugins: { preflight: false } };</script>
 </head>
-<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-[#f7faf9]">
+<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-white">
 
   <!-- HEADER (mesmo do site) -->
   <header class="site-header">
     <div class="container nav">
-      <a class="brand" href="/"><span class="logo"></span><strong>Chicas Eventos</strong></a>
+      <a class="brand" href="../index.html"><span class="logo"></span><strong>Chicas Eventos</strong></a>
       <button class="hamb md:tw-hidden" id="hamb" aria-label="Abrir menu">☰</button>
       <nav class="tw-hidden md:tw-block">
         <ul class="nav-list">
-          <li><a href="/pages/servicos.html" class="is-active">Serviços</a></li>
-          <li><a href="/pages/portfolio.html">Portfólio</a></li>
-          <li><a href="/pages/sobre.html">Sobre</a></li>
-          <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+          <li><a href="servicos.html" class="is-active">Serviços</a></li>
+          <li><a href="portfolio.html">Portfólio</a></li>
+          <li><a href="sobre.html">Sobre</a></li>
+          <li><a class="nav-cta" href="briefing.html">Fazer orçamento</a></li>
         </ul>
       </nav>
     </div>
     <ul id="menuMobile" class="nav-mobile" style="display:none">
-      <li><a href="/pages/servicos.html">Serviços</a></li>
-      <li><a href="/pages/portfolio.html">Portfólio</a></li>
-      <li><a href="/pages/sobre.html">Sobre</a></li>
-      <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+      <li><a href="servicos.html">Serviços</a></li>
+      <li><a href="portfolio.html">Portfólio</a></li>
+      <li><a href="sobre.html">Sobre</a></li>
+      <li><a class="nav-cta" href="briefing.html">Fazer orçamento</a></li>
     </ul>
   </header>
 
@@ -39,7 +39,7 @@
 
       <!-- Título + Sub -->
       <header class="tw-text-center tw-max-w-3xl tw-mx-auto tw-mb-8">
-        <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-emerald-700 tw-uppercase">Serviços</span>
+        <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-slate-900 tw-uppercase">Serviços</span>
         <h1 class="tw-text-3xl md:tw-text-4xl tw-font-extrabold tw-text-slate-900 tw-mt-1">
           Tudo que seu evento precisa, do jeito certo
         </h1>
@@ -51,26 +51,26 @@
 
       <!-- Botões de seleção -->
       <div class="tw-flex tw-flex-wrap tw-gap-3 tw-justify-center tw-mb-8">
-        <button class="svc-btn tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm"
+        <button class="svc-btn tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800"
                 data-key="buffet">🍽️ Buffet</button>
-        <button class="svc-btn tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm"
+        <button class="svc-btn tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800"
                 data-key="audiovisual">🎥 Audiovisual</button>
-        <button class="svc-btn tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm"
+        <button class="svc-btn tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800"
                 data-key="cerimonial">📋 Cerimonial</button>
-        <button class="svc-btn tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm"
+        <button class="svc-btn tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800"
                 data-key="rh">🧑‍🍳 Equipe (RH)</button>
       </div>
 
       <!-- CARD dinâmico -->
       <section id="svcCard"
-        class="tw-relative tw-overflow-hidden tw-rounded-[24px] tw-border tw-border-slate-200 tw-bg-white tw-shadow-xl tw-grid md:tw-grid-cols-2">
+        class="tw-relative tw-overflow-hidden tw-rounded-[24px] tw-border tw-border-slate-200 tw-bg-white tw-grid md:tw-grid-cols-2">
 
         <!-- Imagem -->
         <div class="tw-relative tw-aspect-[16/10] md:tw-aspect-auto tw-min-h-[260px]">
-          <img id="svcImg" src="../assets/public/img/servicos/buffet.jpg" alt="Imagem do serviço"
+          <img id="svcImg" src="../assets/public/img/buffet/buffet1.jpg" alt="Imagem do serviço"
                class="tw-absolute tw-inset-0 tw-w-full tw-h-full tw-object-cover">
           <!-- etiqueta -->
-          <div class="tw-absolute tw-top-4 tw-left-4 tw-bg-emerald-700/90 tw-text-white tw-text-xs tw-font-semibold tw-tracking-wider tw-rounded-full tw-px-3 tw-py-1"
+          <div class="tw-absolute tw-top-4 tw-left-4 tw-bg-slate-900/90 tw-text-white tw-text-xs tw-font-semibold tw-tracking-wider tw-rounded-full tw-px-3 tw-py-1"
                id="svcTag">BUFFET</div>
         </div>
 
@@ -88,8 +88,8 @@
           </ul>
 
           <div class="tw-pt-2">
-            <a id="svcCTA" href="/pages/servicos/buffet.html"
-               class="tw-inline-flex tw-items-center tw-justify-center tw-gap-2 tw-px-5 tw-py-3 tw-rounded-xl tw-font-semibold tw-shadow tw-bg-emerald-700 tw-text-white hover:tw-opacity-95">
+            <a id="svcCTA" href="servicos/buffet.html"
+               class="tw-inline-flex tw-items-center tw-justify-center tw-gap-2 tw-px-5 tw-py-3 tw-rounded-lg tw-font-semibold tw-bg-slate-900 tw-text-white hover:tw-opacity-90">
               Ver detalhes do Buffet →
             </a>
           </div>
@@ -121,10 +121,10 @@
       <div class="f-col">
         <h4 class="f-title">Navegue pelo site</h4>
         <ul class="f-links">
-          <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-          <li><a href="/pages/portfolio.html">Galeria</a></li>
-          <li><a href="/pages/sobre.html">Sobre Nós</a></li>
-          <li><a href="/pages/briefing.html">Contato</a></li>
+          <li><a href="servicos/buffet.html">Buffet</a></li>
+          <li><a href="portfolio.html">Galeria</a></li>
+          <li><a href="sobre.html">Sobre Nós</a></li>
+          <li><a href="briefing.html">Contato</a></li>
         </ul>
       </div>
       <div class="f-col">
@@ -165,7 +165,7 @@ const SERVICES = {
       'Montagem, serviço e logística',
       'Opções sem lactose/veg/vegana'
     ],
-    ctaHref: '/pages/servicos/buffet.html',
+    ctaHref: 'servicos/buffet.html',
     ctaText: 'Ver detalhes do Buffet →'
   },
   audiovisual: {
@@ -178,7 +178,7 @@ const SERVICES = {
       'Drone & captação aérea (onde permitido)',
       'Entrega rápida de reels/stories'
     ],
-    ctaHref: '/pages/servicos/audiovisual.html',
+    ctaHref: 'servicos/audiovisual.html',
     ctaText: 'Ver detalhes de Audiovisual →'
   },
   cerimonial: {
@@ -191,7 +191,7 @@ const SERVICES = {
       'Gestão de fornecedores e prazos',
       'Coordenação completa no grande dia'
     ],
-    ctaHref: '/pages/servicos/cerimonial.html',
+    ctaHref: 'servicos/cerimonial.html',
     ctaText: 'Ver detalhes do Cerimonial →'
   },
   rh: {
@@ -204,7 +204,7 @@ const SERVICES = {
       'Equipe uniformizada e orientada',
       'Cobertura do início ao fim'
     ],
-    ctaHref: '/pages/servicos/rh.html',
+    ctaHref: 'servicos/rh.html',
     ctaText: 'Ver detalhes da Equipe →'
   }
 };
@@ -218,9 +218,9 @@ const SERVICES = {
 
     function setActive(btn){
       document.querySelectorAll('.svc-btn').forEach(b=>{
-        b.classList.remove('tw-bg-emerald-700','tw-text-white','tw-border-emerald-700');
+        b.classList.remove('tw-bg-slate-900','tw-text-white','tw-border-slate-900');
       });
-      btn.classList.add('tw-bg-emerald-700','tw-text-white','tw-border-emerald-700');
+      btn.classList.add('tw-bg-slate-900','tw-text-white','tw-border-slate-900');
     }
 
     function renderService(key, btn){

--- a/pages/servicos/audiovisual.html
+++ b/pages/servicos/audiovisual.html
@@ -17,18 +17,18 @@
     .modal.open{display:flex}
   </style>
 </head>
-<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-[#f7faf9]">
+<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-white">
 <header class="site-header">
   <div class="container nav">
-    <a class="brand" href="/"><span class="logo"></span><strong>Chicas Eventos</strong></a>
+    <a class="brand" href="../../index.html"><span class="logo"></span><strong>Chicas Eventos</strong></a>
     <button class="hamb md:tw-hidden" id="hamb">☰</button>
     <nav class="tw-hidden md:tw-block">
       <ul class="nav-list">
-        <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-        <li><a class="is-active" href="/pages/servicos/audiovisual.html">Audiovisual</a></li>
-        <li><a href="/pages/servicos/rh.html">RH</a></li>
-        <li><a href="/pages/servicos/cerimonial.html">Cerimonial</a></li>
-        <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+        <li><a href="buffet.html">Buffet</a></li>
+        <li><a class="is-active" href="audiovisual.html">Audiovisual</a></li>
+        <li><a href="rh.html">RH</a></li>
+        <li><a href="cerimonial.html">Cerimonial</a></li>
+        <li><a class="nav-cta" href="../briefing.html">Fazer orçamento</a></li>
       </ul>
     </nav>
   </div>
@@ -37,7 +37,7 @@
 <main class="tw-flex-1 tw-py-10">
   <div class="tw-container tw-mx-auto tw-max-w-6xl tw-px-4">
     <header class="tw-text-center tw-max-w-3xl tw-mx-auto">
-      <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-emerald-700 tw-uppercase">Serviço</span>
+      <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-slate-900 tw-uppercase">Serviço</span>
       <h1 class="tw-text-3xl md:tw-text-4xl tw-font-extrabold tw-text-slate-900 tw-mt-1">Audiovisual</h1>
       <p class="tw-text-slate-600 tw-mt-2">Foto, vídeo, drone e social media. Conteúdo com linguagem de marca e entrega rápida.</p>
     </header>
@@ -56,7 +56,7 @@
 </main>
 
 <div id="modal" class="modal tw-items-center tw-justify-center tw-px-4">
-  <div class="tw-bg-white tw-rounded-2xl tw-w-full tw-max-w-4xl tw-shadow-2xl tw-overflow-hidden">
+  <div class="tw-bg-white tw-rounded-2xl tw-w-full tw-max-w-4xl tw-overflow-hidden">
     <div class="tw-flex tw-justify-between tw-items-start tw-gap-4 tw-p-5 tw-border-b tw-border-slate-200">
       <div><h3 id="mTitle" class="tw-text-2xl tw-font-extrabold tw-text-slate-900">Título</h3><p id="mMeta" class="tw-text-sm tw-text-slate-500">Audiovisual</p></div>
       <button id="mClose" class="tw-rounded-lg tw-p-2 tw-bg-slate-100 hover:tw-bg-slate-200">✕</button>
@@ -66,8 +66,8 @@
       <div class="md:tw-col-span-2">
         <div class="tw-relative tw-rounded-xl tw-overflow-hidden tw-aspect-[16/9] tw-bg-slate-100">
           <img id="mHero" class="tw-absolute tw-inset-0 tw-w-full tw-h-full tw-object-cover">
-          <button id="mPrev" class="tw-absolute tw-left-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2 tw-shadow">‹</button>
-          <button id="mNext" class="tw-absolute tw-right-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2 tw-shadow">›</button>
+          <button id="mPrev" class="tw-absolute tw-left-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2">‹</button>
+          <button id="mNext" class="tw-absolute tw-right-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2">›</button>
         </div>
         <div id="mThumbs" class="tw-grid tw-grid-cols-5 tw-gap-2 tw-mt-3"></div>
       </div>
@@ -94,7 +94,7 @@
   // modal engine (igual buffet)
   const modal=document.getElementById('modal'), mTitle=document.getElementById('mTitle'), mMeta=document.getElementById('mMeta'), mDesc=document.getElementById('mDesc'), mBullets=document.getElementById('mBullets'), mHero=document.getElementById('mHero'), mThumbs=document.getElementById('mThumbs'), mPrev=document.getElementById('mPrev'), mNext=document.getElementById('mNext'), mClose=document.getElementById('mClose'); let gallery=[], idx=0;
   function openModal(id){const d=CARDS[id]; if(!d) return; mTitle.textContent=d.title; mMeta.textContent='Audiovisual'; mDesc.textContent=d.desc||''; mBullets.innerHTML=(d.bullets||[]).map(x=>`<li>${x}</li>`).join(''); gallery=d.images||['../../assets/public/img/org/ale.jpg']; idx=0; updateHero(); buildThumbs(); modal.classList.add('open'); document.body.style.overflow='hidden';}
-  function updateHero(){mHero.src=gallery[idx]; Array.from(mThumbs.children).forEach((t,i)=>{t.classList.toggle('tw-ring-2',i===idx); t.classList.toggle('tw-ring-emerald-600',i===idx);});}
+  function updateHero(){mHero.src=gallery[idx]; Array.from(mThumbs.children).forEach((t,i)=>{t.classList.toggle('tw-ring-2',i===idx); t.classList.toggle('tw-ring-slate-900',i===idx);});}
   function buildThumbs(){mThumbs.innerHTML=''; gallery.forEach((s,i)=>{const im=document.createElement('img'); im.src=s; im.className='tw-w-full tw-h-20 tw-object-cover tw-rounded-lg tw-cursor-pointer'; im.onclick=()=>{idx=i;updateHero();}; mThumbs.appendChild(im);});}
   function close(){modal.classList.remove('open'); document.body.style.overflow='';}
   mClose.onclick=close; modal.addEventListener('click',e=>{if(e.target===modal) close();}); document.addEventListener('keydown',e=>{if(!modal.classList.contains('open')) return; if(e.key==='Escape') close(); if(e.key==='ArrowRight'){idx=(idx+1)%gallery.length;updateHero();} if(e.key==='ArrowLeft'){idx=(idx-1+gallery.length)%gallery.length;updateHero();}});

--- a/pages/servicos/buffet.html
+++ b/pages/servicos/buffet.html
@@ -18,29 +18,29 @@
     .modal.open{display:flex}
   </style>
 </head>
-<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-[#f7faf9]">
+<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-white">
 
   <!-- HEADER -->
   <header class="site-header">
     <div class="container nav">
-      <a class="brand" href="/"><span class="logo"></span><strong>Chicas Eventos</strong></a>
+      <a class="brand" href="../../index.html"><span class="logo"></span><strong>Chicas Eventos</strong></a>
       <button class="hamb md:tw-hidden" id="hamb">☰</button>
       <nav class="tw-hidden md:tw-block">
         <ul class="nav-list">
-          <li><a class="is-active" href="/pages/servicos/buffet.html">Buffet</a></li>
-          <li><a href="/pages/servicos/audiovisual.html">Audiovisual</a></li>
-          <li><a href="/pages/servicos/rh.html">RH</a></li>
-          <li><a href="/pages/servicos/cerimonial.html">Cerimonial</a></li>
-          <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+          <li><a class="is-active" href="buffet.html">Buffet</a></li>
+          <li><a href="audiovisual.html">Audiovisual</a></li>
+          <li><a href="rh.html">RH</a></li>
+          <li><a href="cerimonial.html">Cerimonial</a></li>
+          <li><a class="nav-cta" href="../briefing.html">Fazer orçamento</a></li>
         </ul>
       </nav>
     </div>
     <ul id="menuMobile" class="nav-mobile" style="display:none">
-      <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-      <li><a href="/pages/servicos/audiovisual.html">Audiovisual</a></li>
-      <li><a href="/pages/servicos/rh.html">RH</a></li>
-      <li><a href="/pages/servicos/cerimonial.html">Cerimonial</a></li>
-      <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+      <li><a href="buffet.html">Buffet</a></li>
+      <li><a href="audiovisual.html">Audiovisual</a></li>
+      <li><a href="rh.html">RH</a></li>
+      <li><a href="cerimonial.html">Cerimonial</a></li>
+      <li><a class="nav-cta" href="../briefing.html">Fazer orçamento</a></li>
     </ul>
   </header>
 
@@ -48,7 +48,7 @@
     <div class="tw-container tw-mx-auto tw-max-w-6xl tw-px-4">
 
       <header class="tw-text-center tw-max-w-3xl tw-mx-auto">
-        <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-emerald-700 tw-uppercase">Serviço</span>
+        <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-slate-900 tw-uppercase">Serviço</span>
         <h1 class="tw-text-3xl md:tw-text-4xl tw-font-extrabold tw-text-slate-900 tw-mt-1">Buffet</h1>
         <p class="tw-text-slate-600 tw-mt-2">
           Cardápios sob medida para cada ocasião: coquetéis, coffee break, brunch e refeições completas. Clique nos cartões para ver os detalhes.
@@ -91,7 +91,7 @@
 
   <!-- MODAL -->
   <div id="modal" class="modal tw-items-center tw-justify-center tw-px-4">
-    <div class="tw-bg-white tw-rounded-2xl tw-w-full tw-max-w-4xl tw-shadow-2xl tw-overflow-hidden">
+    <div class="tw-bg-white tw-rounded-2xl tw-w-full tw-max-w-4xl tw-overflow-hidden">
       <div class="tw-flex tw-justify-between tw-items-start tw-gap-4 tw-p-5 tw-border-b tw-border-slate-200">
         <div>
           <h3 id="mTitle" class="tw-text-2xl tw-font-extrabold tw-text-slate-900">Título</h3>
@@ -107,8 +107,8 @@
         <div class="md:tw-col-span-2">
           <div class="tw-relative tw-rounded-xl tw-overflow-hidden tw-aspect-[16/9] tw-bg-slate-100">
             <img id="mHero" class="tw-absolute tw-inset-0 tw-w-full tw-h-full tw-object-cover" src="">
-            <button id="mPrev" class="tw-absolute tw-left-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2 tw-shadow">‹</button>
-            <button id="mNext" class="tw-absolute tw-right-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2 tw-shadow">›</button>
+            <button id="mPrev" class="tw-absolute tw-left-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2">‹</button>
+            <button id="mNext" class="tw-absolute tw-right-2 tw-top-1/2 -tw-translate-y-1/2 tw-bg-white/80 hover:tw-bg-white tw-rounded-full tw-p-2">›</button>
           </div>
           <div id="mThumbs" class="tw-grid tw-grid-cols-5 tw-gap-2 tw-mt-3"></div>
         </div>
@@ -127,10 +127,10 @@
       <div class="f-col">
         <h4 class="f-title">Navegue</h4>
         <ul class="f-links">
-          <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-          <li><a href="/pages/servicos/audiovisual.html">Audiovisual</a></li>
-          <li><a href="/pages/servicos/rh.html">RH</a></li>
-          <li><a href="/pages/servicos/cerimonial.html">Cerimonial</a></li>
+          <li><a href="buffet.html">Buffet</a></li>
+          <li><a href="audiovisual.html">Audiovisual</a></li>
+          <li><a href="rh.html">RH</a></li>
+          <li><a href="cerimonial.html">Cerimonial</a></li>
         </ul>
       </div>
       <div class="f-col">
@@ -229,7 +229,7 @@
       idx=0; updateHero(); buildThumbs();
       modal.classList.add('open'); document.body.style.overflow='hidden';
     }
-    function updateHero(){ mHero.src=gallery[idx]; Array.from(mThumbs.children).forEach((t,i)=>{t.classList.toggle('tw-ring-2',i===idx); t.classList.toggle('tw-ring-emerald-600',i===idx);}); }
+    function updateHero(){ mHero.src=gallery[idx]; Array.from(mThumbs.children).forEach((t,i)=>{t.classList.toggle('tw-ring-2',i===idx); t.classList.toggle('tw-ring-slate-900',i===idx);}); }
     function buildThumbs(){ mThumbs.innerHTML=''; gallery.forEach((src,i)=>{const im=document.createElement('img'); im.src=src; im.className='tw-w-full tw-h-20 tw-object-cover tw-rounded-lg tw-cursor-pointer'; im.onclick=()=>{idx=i;updateHero();}; mThumbs.appendChild(im);}); }
     function close(){ modal.classList.remove('open'); document.body.style.overflow=''; }
     mClose.onclick=close; modal.addEventListener('click',e=>{ if(e.target===modal) close(); });

--- a/pages/servicos/cerimonial.html
+++ b/pages/servicos/cerimonial.html
@@ -17,18 +17,18 @@
     .modal.open{display:flex}
   </style>
 </head>
-<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-[#f7faf9]">
+<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-white">
 <header class="site-header">
   <div class="container nav">
-    <a class="brand" href="/"><span class="logo"></span><strong>Chicas Eventos</strong></a>
+    <a class="brand" href="../../index.html"><span class="logo"></span><strong>Chicas Eventos</strong></a>
     <button class="hamb md:tw-hidden" id="hamb">☰</button>
     <nav class="tw-hidden md:tw-block">
       <ul class="nav-list">
-        <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-        <li><a href="/pages/servicos/audiovisual.html">Audiovisual</a></li>
-        <li><a href="/pages/servicos/rh.html">RH</a></li>
-        <li><a class="is-active" href="/pages/servicos/cerimonial.html">Cerimonial</a></li>
-        <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+        <li><a href="buffet.html">Buffet</a></li>
+        <li><a href="audiovisual.html">Audiovisual</a></li>
+        <li><a href="rh.html">RH</a></li>
+        <li><a class="is-active" href="cerimonial.html">Cerimonial</a></li>
+        <li><a class="nav-cta" href="../briefing.html">Fazer orçamento</a></li>
       </ul>
     </nav>
   </div>
@@ -37,7 +37,7 @@
 <main class="tw-flex-1 tw-py-10">
   <div class="tw-container tw-mx-auto tw-max-w-6xl tw-px-4">
     <header class="tw-text-center tw-max-w-3xl tw-mx-auto">
-      <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-emerald-700 tw-uppercase">Serviço</span>
+      <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-slate-900 tw-uppercase">Serviço</span>
       <h1 class="tw-text-3xl md:tw-text-4xl tw-font-extrabold tw-text-slate-900 tw-mt-1">Cerimonial & Produção</h1>
       <p class="tw-text-slate-600 tw-mt-2">Planejamento, cronograma, fornecedores e execução no dia. Você curte, a gente coordena.</p>
     </header>

--- a/pages/servicos/rh.html
+++ b/pages/servicos/rh.html
@@ -17,18 +17,18 @@
     .modal.open{display:flex}
   </style>
 </head>
-<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-[#f7faf9]">
+<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-white">
 <header class="site-header">
   <div class="container nav">
-    <a class="brand" href="/"><span class="logo"></span><strong>Chicas Eventos</strong></a>
+    <a class="brand" href="../../index.html"><span class="logo"></span><strong>Chicas Eventos</strong></a>
     <button class="hamb md:tw-hidden" id="hamb">☰</button>
     <nav class="tw-hidden md:tw-block">
       <ul class="nav-list">
-        <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-        <li><a href="/pages/servicos/audiovisual.html">Audiovisual</a></li>
-        <li><a class="is-active" href="/pages/servicos/rh.html">RH</a></li>
-        <li><a href="/pages/servicos/cerimonial.html">Cerimonial</a></li>
-        <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+        <li><a href="buffet.html">Buffet</a></li>
+        <li><a href="audiovisual.html">Audiovisual</a></li>
+        <li><a class="is-active" href="rh.html">RH</a></li>
+        <li><a href="cerimonial.html">Cerimonial</a></li>
+        <li><a class="nav-cta" href="../briefing.html">Fazer orçamento</a></li>
       </ul>
     </nav>
   </div>
@@ -37,7 +37,7 @@
 <main class="tw-flex-1 tw-py-10">
   <div class="tw-container tw-mx-auto tw-max-w-6xl tw-px-4">
     <header class="tw-text-center tw-max-w-3xl tw-mx-auto">
-      <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-emerald-700 tw-uppercase">Serviço</span>
+      <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-slate-900 tw-uppercase">Serviço</span>
       <h1 class="tw-text-3xl md:tw-text-4xl tw-font-extrabold tw-text-slate-900 tw-mt-1">Equipe Operacional (RH)</h1>
       <p class="tw-text-slate-600 tw-mt-2">Garçons, recepção, segurança e apoio. Escala planejada e briefing antes do evento.</p>
     </header>

--- a/pages/sobre.html
+++ b/pages/sobre.html
@@ -9,27 +9,27 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script> tailwind.config = { prefix: 'tw-', corePlugins: { preflight: false } };</script>
 </head>
-<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-[#f7faf9]">
+<body class="tw-min-h-screen tw-flex tw-flex-col tw-bg-white">
 
   <!-- HEADER igual -->
   <header class="site-header">
     <div class="container nav">
-      <a class="brand" href="/"><span class="logo"></span><strong>Chicas Eventos</strong></a>
+      <a class="brand" href="../index.html"><span class="logo"></span><strong>Chicas Eventos</strong></a>
       <button class="hamb md:tw-hidden" id="hamb" aria-label="Abrir menu">☰</button>
       <nav class="tw-hidden md:tw-block">
         <ul class="nav-list">
-          <li><a href="/pages/servicos.html">Serviços</a></li>
-          <li><a href="/pages/portfolio.html">Portfólio</a></li>
-          <li><a class="is-active" href="/pages/sobre.html">Sobre</a></li>
-          <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+          <li><a href="servicos.html">Serviços</a></li>
+          <li><a href="portfolio.html">Portfólio</a></li>
+          <li><a class="is-active" href="sobre.html">Sobre</a></li>
+          <li><a class="nav-cta" href="briefing.html">Fazer orçamento</a></li>
         </ul>
       </nav>
     </div>
     <ul id="menuMobile" class="nav-mobile" style="display:none">
-      <li><a href="/pages/servicos.html">Serviços</a></li>
-      <li><a href="/pages/portfolio.html">Portfólio</a></li>
-      <li><a href="/pages/sobre.html">Sobre</a></li>
-      <li><a class="nav-cta" href="/pages/briefing.html">Fazer orçamento</a></li>
+      <li><a href="servicos.html">Serviços</a></li>
+      <li><a href="portfolio.html">Portfólio</a></li>
+      <li><a href="sobre.html">Sobre</a></li>
+      <li><a class="nav-cta" href="briefing.html">Fazer orçamento</a></li>
     </ul>
   </header>
 
@@ -37,7 +37,7 @@
     <!-- Hero -->
     <section class="tw-py-12 md:tw-py-16">
       <div class="tw-container tw-mx-auto tw-max-w-6xl tw-px-4 tw-text-center">
-        <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-emerald-700 tw-uppercase">Quem somos</span>
+        <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-slate-900 tw-uppercase">Quem somos</span>
         <h1 class="tw-text-3xl md:tw-text-5xl tw-font-extrabold tw-text-slate-900 tw-mt-2">Histórias servidas com sabor e cuidado</h1>
         <p class="tw-text-slate-600 tw-mt-3 tw-max-w-2xl tw-mx-auto">
           A Chicas nasceu da vontade de transformar encontros em memórias. Da cozinha ao cerimonial,
@@ -64,10 +64,10 @@
             </p>
           </div>
           <div class="tw-grid tw-gap-4">
-            <img src="../assets/public/img/buffet/buffet2.jpg" class="tw-w-full tw-rounded-2xl tw-shadow-md tw-object-cover tw-aspect-[16/10]" alt="Buffet em evento">
+            <img src="../assets/public/img/buffet/buffet2.jpg" class="tw-w-full tw-rounded-2xl tw-object-cover tw-aspect-[16/10]" alt="Buffet em evento">
             <div class="tw-grid md:tw-grid-cols-2 tw-gap-4">
-              <img src="../assets/public/img/aud/cobertura1.jpg" class="tw-w-full tw-rounded-2xl tw-shadow-md tw-object-cover tw-aspect-[16/10]" alt="Cobertura audiovisual">
-              <img src="../assets/public/img/rh/operacional1.jpg" class="tw-w-full tw-rounded-2xl tw-shadow-md tw-object-cover tw-aspect-[16/10]" alt="Equipe operacional">
+              <img src="../assets/public/img/aud/cobertura1.jpg" class="tw-w-full tw-rounded-2xl tw-object-cover tw-aspect-[16/10]" alt="Cobertura audiovisual">
+              <img src="../assets/public/img/rh/operacional1.jpg" class="tw-w-full tw-rounded-2xl tw-object-cover tw-aspect-[16/10]" alt="Equipe operacional">
             </div>
           </div>
         </div>
@@ -81,16 +81,16 @@
           <h3 class="tw-text-xl md:tw-text-2xl tw-font-extrabold tw-text-slate-900">O que guiamos em cada projeto</h3>
         </div>
         <div class="tw-grid md:tw-grid-cols-3 tw-gap-6">
-          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-shadow p-6">
-            <div class="tw-text-emerald-700 tw-font-bold tw-mb-1">Cuidado</div>
+          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl p-6">
+            <div class="tw-text-slate-900 tw-font-bold tw-mb-1">Cuidado</div>
             <p class="tw-text-slate-700">Atenção aos detalhes: do menu ao fluxo de convidados.</p>
           </div>
-          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-shadow p-6">
-            <div class="tw-text-emerald-700 tw-font-bold tw-mb-1">Agilidade</div>
+          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl p-6">
+            <div class="tw-text-slate-900 tw-font-bold tw-mb-1">Agilidade</div>
             <p class="tw-text-slate-700">Processos claros, prazos cumpridos e comunicação direta.</p>
           </div>
-          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-shadow p-6">
-            <div class="tw-text-emerald-700 tw-font-bold tw-mb-1">Personalização</div>
+          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl p-6">
+            <div class="tw-text-slate-900 tw-font-bold tw-mb-1">Personalização</div>
             <p class="tw-text-slate-700">Propostas sob medida para o seu público e orçamento.</p>
           </div>
         </div>
@@ -100,10 +100,10 @@
     <!-- CTA -->
     <section class="tw-py-8">
       <div class="tw-container tw-mx-auto tw-max-w-6xl tw-px-4">
-        <div class="tw-text-center tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-shadow tw-p-6 md:tw-p-8">
+        <div class="tw-text-center tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-p-6 md:tw-p-8">
           <h4 class="tw-text-xl tw-font-extrabold tw-text-slate-900">Vamos planejar seu próximo evento?</h4>
           <p class="tw-text-slate-700 tw-mt-2">Leva 2 min pra enviar o briefing. A gente responde rapidinho!</p>
-          <a href="/pages/briefing.html" class="tw-inline-flex tw-items-center tw-justify-center tw-px-6 tw-py-3 tw-rounded-xl tw-font-semibold tw-shadow tw-bg-emerald-700 tw-text-white tw-mt-4 hover:tw-opacity-95">
+          <a href="briefing.html" class="tw-inline-flex tw-items-center tw-justify-center tw-px-6 tw-py-3 tw-rounded-xl tw-font-semibold tw-bg-slate-900 tw-text-white tw-mt-4 hover:tw-opacity-95">
             Fazer orçamento →
           </a>
         </div>
@@ -114,7 +114,7 @@
     <section class="tw-py-10">
       <div class="tw-container tw-mx-auto tw-max-w-6xl tw-px-4">
         <div class="tw-text-center tw-mb-6">
-          <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-emerald-700 tw-uppercase">Contato</span>
+          <span class="tw-text-xs tw-font-semibold tw-tracking-widest tw-text-slate-900 tw-uppercase">Contato</span>
           <h3 class="tw-text-2xl tw-font-extrabold tw-text-slate-900">Fale com a gente</h3>
           <p class="tw-text-slate-600 tw-mt-2">Dúvidas rápidas? Chama no Whats ou no Instagram.</p>
         </div>
@@ -122,39 +122,39 @@
         <div class="tw-grid md:tw-grid-cols-3 tw-gap-6">
           <!-- WhatsApp -->
           <a href="https://wa.me/5599999999999" target="_blank" rel="noopener"
-             class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-shadow tw-p-6 tw-flex tw-flex-col tw-gap-2 hover:tw-border-emerald-600">
+             class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-p-6 tw-flex tw-flex-col tw-gap-2 hover:tw-border-slate-900">
             <div class="tw-text-slate-500 tw-text-sm">WhatsApp</div>
             <div class="tw-text-slate-900 tw-font-bold tw-text-lg">+55 (99) 99999-9999</div>
-            <div class="tw-text-emerald-700 tw-font-semibold">Abrir conversa →</div>
+            <div class="tw-text-slate-900 tw-font-semibold">Abrir conversa →</div>
           </a>
 
           <!-- E-mail -->
           <a href="mailto:contato@chicas.com.br"
-             class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-shadow tw-p-6 tw-flex tw-flex-col tw-gap-2 hover:tw-border-emerald-600">
+             class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-p-6 tw-flex tw-flex-col tw-gap-2 hover:tw-border-slate-900">
             <div class="tw-text-slate-500 tw-text-sm">E-mail</div>
             <div class="tw-text-slate-900 tw-font-bold tw-text-lg">contato@chicas.com.br</div>
-            <div class="tw-text-emerald-700 tw-font-semibold">Enviar e-mail →</div>
+            <div class="tw-text-slate-900 tw-font-semibold">Enviar e-mail →</div>
           </a>
 
           <!-- Instagram -->
           <a href="https://instagram.com/seuuser" target="_blank" rel="noopener"
-             class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-shadow tw-p-6 tw-flex tw-flex-col tw-gap-2 hover:tw-border-emerald-600">
+             class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-p-6 tw-flex tw-flex-col tw-gap-2 hover:tw-border-slate-900">
             <div class="tw-text-slate-500 tw-text-sm">Instagram</div>
             <div class="tw-text-slate-900 tw-font-bold tw-text-lg">@seuuser</div>
-            <div class="tw-text-emerald-700 tw-font-semibold">Ver perfil →</div>
+            <div class="tw-text-slate-900 tw-font-semibold">Ver perfil →</div>
           </a>
         </div>
 
         <!-- Endereço + Mapa -->
         <div class="tw-grid md:tw-grid-cols-2 tw-gap-6 tw-mt-6">
-          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-shadow tw-p-6">
+          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-p-6">
             <div class="tw-text-slate-500 tw-text-sm">Endereço</div>
             <div class="tw-text-slate-900 tw-font-bold">Rua Exemplo, 123 — Centro, Sua Cidade</div>
             <p class="tw-text-slate-700 tw-mt-2">Atendimento com hora marcada.</p>
           </div>
 
           <!-- MAPA -->
-          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-shadow tw-overflow-hidden">
+          <div class="tw-bg-white tw-border tw-border-slate-200 tw-rounded-2xl tw-overflow-hidden">
             <div class="tw-aspect-[16/9]">
               <iframe
                 src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3656.523640318688!2d-46.662325!3d-23.585593!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x94ce59c8b3b1c1ad%3A0x0000000000000000!2sSeu%20Endere%C3%A7o!5e0!3m2!1spt-BR!2sBR!4v0000000000000"
@@ -182,10 +182,10 @@
       <div class="f-col">
         <h4 class="f-title">Navegue pelo site</h4>
         <ul class="f-links">
-          <li><a href="/pages/servicos/buffet.html">Buffet</a></li>
-          <li><a href="/pages/portfolio.html">Galeria</a></li>
-          <li><a href="/pages/sobre.html">Sobre Nós</a></li>
-          <li><a href="/pages/briefing.html">Contato</a></li>
+          <li><a href="servicos/buffet.html">Buffet</a></li>
+          <li><a href="portfolio.html">Galeria</a></li>
+          <li><a href="sobre.html">Sobre Nós</a></li>
+          <li><a href="briefing.html">Contato</a></li>
         </ul>
       </div>
       <div class="f-col">


### PR DESCRIPTION
## Summary
- fix navigation to use relative links
- rename `serviços` pages to `servicos` and update references
- correct initial service image path
- apply minimalistic theme with neutral palette and simpler components

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5233e65ac832fbb708746e141b9c7