### PR TITLE
Add images to briefing options

### DIFF
--- a/pages/briefing.html
+++ b/pages/briefing.html
@@ -103,10 +103,22 @@
               </div>
               <div id="buffetTipos" class="tw-hidden tw-grid tw-gap-3 md:tw-grid-cols-2">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700 md:tw-col-span-2">Que tipo de buffet?</label>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Coffee break">Coffee break</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Coquetel">Coquetel</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Brunch">Brunch</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Almoço/Jantar">Almoço/Jantar</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Coffee break">
+                  <img src="../assets/public/img/buffet/Coffeebreak1.jpg" alt="Coffee break" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Coffee break
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Coquetel">
+                  <img src="../assets/public/img/buffet/coqueteis1.jpg" alt="Coquetel" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Coquetel
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Brunch">
+                  <img src="../assets/public/img/buffet/brunch.jpg" alt="Brunch" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Brunch
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300 tw-transition" data-multi="tipo_buffet" data-value="Almoço/Jantar">
+                  <img src="../assets/public/img/buffet/buffet.jpg" alt="Almoço ou Jantar" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Almoço/Jantar
+                </button>
               </div>
               <div id="buffetCustomWrap" class="tw-hidden tw-mt-4">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700">Preferências do buffet (opcional)</label>
@@ -123,11 +135,26 @@
               </div>
               <div id="audTipos" class="tw-hidden tw-grid tw-gap-3 md:tw-grid-cols-3">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700 md:tw-col-span-3">De que tipo?</label>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Foto">Foto</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Vídeo">Vídeo</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Drone">Drone</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Social media (reels/stories)">Social media</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Pacote completo">Pacote completo</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Foto">
+                  <img src="../assets/public/img/aud/fotografo1.jpg" alt="Foto" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Foto
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Vídeo">
+                  <img src="../assets/public/img/aud/cobertura1.jpg" alt="Vídeo" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Vídeo
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Drone">
+                  <img src="../assets/public/img/aud/cobertura3.jpg" alt="Drone" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Drone
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Social media (reels/stories)">
+                  <img src="../assets/public/img/aud/fotografo4.jpg" alt="Social media" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Social media
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_aud" data-value="Pacote completo">
+                  <img src="../assets/public/img/aud/cobertura.jpg" alt="Pacote completo" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Pacote completo
+                </button>
               </div>
             </div>
 
@@ -140,10 +167,22 @@
               </div>
               <div id="rhTipos" class="tw-hidden tw-grid tw-gap-3 md:tw-grid-cols-2">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700 md:tw-col-span-2">Qual(is) desses?</label>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Garçom">Garçom</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Recepcionista">Recepcionista</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Segurança">Segurança</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Apoio/Operacional">Apoio/Operacional</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Garçom">
+                  <img src="../assets/public/img/rh/operacional1.jpg" alt="Garçom" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Garçom
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Recepcionista">
+                  <img src="../assets/public/img/rh/operacional2.jpg" alt="Recepcionista" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Recepcionista
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Segurança">
+                  <img src="../assets/public/img/rh/operacional3.jpg" alt="Segurança" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Segurança
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-multi="tipo_rh" data-value="Apoio/Operacional">
+                  <img src="../assets/public/img/rh/operacional4.jpg" alt="Apoio ou Operacional" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Apoio/Operacional
+                </button>
               </div>
             </div>
 
@@ -152,8 +191,14 @@
               <h2 class="tw-text-base tw-font-bold tw-text-slate-900 tw-mb-3">6) Cerimonial</h2>
               <p class="tw-text-slate-700 tw-mb-3">Nosso cerimonial cuida do planejamento completo, cronograma, fornecedores e execução no dia.</p>
               <div class="tw-flex tw-gap-3 tw-flex-wrap">
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-toggle="cerim" data-value="sim">Quero cerimonial</button>
-                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-toggle="cerim" data-value="nao">Não preciso</button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-toggle="cerim" data-value="sim">
+                  <img src="../assets/public/img/org/ale.jpg" alt="Cerimonial" class="tw-w-10 tw-h-10 tw-object-cover tw-rounded-full">
+                  Quero cerimonial
+                </button>
+                <button type="button" class="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-rounded-full tw-border tw-border-slate-200 tw-bg-white tw-text-slate-800 tw-shadow-sm hover:tw-border-slate-300" data-toggle="cerim" data-value="nao">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="tw-w-8 tw-h-8 tw-text-slate-400"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+                  Não preciso
+                </button>
               </div>
               <div class="tw-mt-4">
                 <label class="tw-text-sm tw-font-semibold tw-text-slate-700">Observações (opcional)</label>


### PR DESCRIPTION
## Summary
- add illustrative images to buffet, audiovisual, RH and cerimonial selections in the briefing form

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b5276c38a0832f86cabf1b8d49d907