### PR TITLE
Adjust briefing header text

### DIFF
--- a/pages/briefing.html
+++ b/pages/briefing.html
@@ -40,10 +40,10 @@
     <div class="tw-container tw-mx-auto tw-max-w-3xl tw-px-4">
       <section class="tw-p-6 md:tw-p-10 tw-rounded-[28px] tw-border tw-border-slate-200 tw-shadow-2xl tw-bg-white/85 tw-backdrop-blur-sm">
         <div class="tw-text-center tw-space-y-4">
-          <h1 class="tw-text-3xl md:tw-text-4xl tw-font-extrabold tw-text-slate-900">Briefing</h1>
-          <p class="tw-text-slate-600">Fill it out quickly and we’ll return with your quote. If you prefer, contact us directly on WhatsApp.</p>
-          <a href="https://wa.me/5599999999999?text=Hello!%20I%E2%80%99d%20like%20a%20quote%20and%20preferred%20to%20contact%20you%20directly%20here." target="_blank" rel="noopener" class="tw-inline-flex tw-items-center tw-justify-center tw-px-4 tw-py-2 tw-rounded-xl tw-font-semibold tw-shadow tw-bg-emerald-700 tw-text-white hover:tw-opacity-95">Contact on WhatsApp now</a>
-        </div>
+          <span class="tw-text-xs tw-tracking-wide tw-font-semibold tw-text-emerald-700 tw-uppercase">Briefing de Evento</span>
+          <h1 class="tw-text-3xl md:tw-text-4xl tw-font-extrabold tw-text-slate-900">Orçamento rápido</h1>
+          <p class="tw-text-slate-600">Leva menos de 2 min. É assim que entendemos sua necessidade e preparamos um orçamento sob medida.</p>
+          <a href="https://wa.me/5599999999999?text=Hello!%20I%E2%80%99d%20like%20a%20quote%20and%20preferred%20to%20contact%20you%20directly%20here." target="_blank" rel="noopener" class="tw-inline-flex tw-items-center tw-justify-center tw-px-4 tw-py-2 tw-rounded-xl tw-font-semibold tw-shadow tw-bg-emerald-700 tw-text-white hover:tw-opacity-95">Contato no WhatsApp agora</a>
 
         <form id="briefingForm" class="tw-mt-8 tw-space-y-6">
           <div>


### PR DESCRIPTION
## Summary
- Localize briefing section with Portuguese heading, description and WhatsApp link text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bee602f3e0832fa4fa7bc6648f94bc